### PR TITLE
Leave system management to xenko

### DIFF
--- a/Samples/ImGuiTool/ImGuiToolApp.cs
+++ b/Samples/ImGuiTool/ImGuiToolApp.cs
@@ -53,9 +53,6 @@ namespace ImGuiTool
 
         protected override void Update(GameTime gameTime)
         {
-            // must happen first!
-            imgui?.Update(gameTime);
-
             base.Update(gameTime);
 
             // show something interesting for now, later add controls that affect the TeaPot below!!
@@ -64,8 +61,6 @@ namespace ImGuiTool
 
         protected override void Draw(GameTime gameTime)
         {
-            base.Draw(gameTime);
-
             // Clear screen
             GraphicsContext.CommandList.Clear(GraphicsDevice.Presenter.BackBuffer, Color.CornflowerBlue);
             GraphicsContext.CommandList.Clear(GraphicsDevice.Presenter.DepthStencilBuffer, DepthStencilClearOptions.DepthBuffer | DepthStencilClearOptions.Stencil);
@@ -85,12 +80,8 @@ namespace ImGuiTool
             
             // Draw
             teapot.Draw(GraphicsContext, simpleEffect);
-        }
 
-        protected override void EndDraw(bool present)
-        {
-            imgui?.Draw();
-            base.EndDraw(present);
+            base.Draw(gameTime);
         }
-    }    
+    }
 }

--- a/Xenko.ImGui/ImGuiSystem.cs
+++ b/Xenko.ImGui/ImGuiSystem.cs
@@ -54,6 +54,14 @@ namespace Xenko.Extensions
             Debug.Assert(effectSystem != null, "ImGuiSystem: EffectSystem must be available!");
 
             Initialize();
+
+            Enabled = true; // Force Update functions to be run
+            Visible = true; // Force Draw related functions to be run
+            UpdateOrder = input.UpdateOrder + 1;
+
+            // Include this new instance into our services and systems so that xenko fires our functions automatically
+            Services.AddService(this);
+            Game.GameSystems.Add(this);
         }
 
         public override void Initialize() 
@@ -199,7 +207,7 @@ namespace Xenko.Extensions
             fontTexture = newFontTexture;
         }
 
-        public new void Update(GameTime gameTime) 
+        public override void Update(GameTime gameTime)
         {
             ImGuiIOPtr io = ImGui.GetIO();
 
@@ -250,7 +258,9 @@ namespace Xenko.Extensions
             ImGui.NewFrame();
         }
 
-        public void Draw() 
+        public override bool BeginDraw() => true; // Tell xenko to execute EndDraw
+
+        public override void EndDraw()
         {
             ImGui.Render();
             RenderDrawLists(ImGui.GetDrawData());


### PR DESCRIPTION
Had to move game draw after your teapot drawing to avoid clearing ImGui ?
The comment inside game update 'must happen first!' is because we have to poll input first, right ?

Now it's as easy as it gets to implement ImGui inside xenko, users just have to spawn a controller instance.